### PR TITLE
Use a link, instead of moving the files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ if [ "${1:-}" = 'RUN' ]; then
 
       if [[ $# -ge 2 ]]; then
         if [[ "$file" == *"${2%.*-}"* ]]; then
-          mv "$destination/${file%.*}.html" "$destination/$(dirname "$file")/index.html"
+          ln "$destination/${file%.*}.html" "$destination/$(dirname "$file")/index.html"
         fi
       fi
 


### PR DESCRIPTION
This keeps cross-references, so that we don't need to modify the produced files to rename `<path>/README.html` to `<path>/index.html`